### PR TITLE
Feature: Restore paste fields from infotext

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ CADS greatly increases diversity of generated images by adding scheduled noise t
 - [x] SD XL support  
 - [x] SD 1.5 support
 - [x] Hi-res fix support
+- [x] Support restoring parameter values from infotext (Send to Txt2Img, Send to Img2Img, etc.)
+- [x] Write infotext to image grids
 - [ ] ControlNet support
-- [ ] Support restoring parameter values from infotext (Send to Txt2Img, Send to Img2Img, etc.)
-- [ ] Write infotext to image grids
 
 ## Credits
 - The authors of the original paper for their method (https://arxiv.org/abs/2310.17347):

--- a/scripts/cads.py
+++ b/scripts/cads.py
@@ -60,6 +60,24 @@ class CADSExtensionScript(scripts.Script):
                 noise_scale.do_not_save_to_config = True
                 mixing_factor.do_not_save_to_config = True
                 apply_to_hr_pass.do_not_save_to_config = True
+                self.infotext_fields = [
+                        (active, 'CADS Active'),
+                        (rescale, 'CADS Rescale'),
+                        (t1, 'CADS Tau 1'),
+                        (t2, 'CADS Tau 2'),
+                        (noise_scale, 'CADS Noise Scale'),
+                        (mixing_factor, 'CADS Mixing Factor'),
+                        (apply_to_hr_pass, 'CADS Apply To Hires. Fix'),
+                ]
+                self.paste_field_names = [
+                        'cads_active',
+                        'cads_rescale',
+                        'cads_tau1',
+                        'cads_tau2',
+                        'cads_noise_scale',
+                        'cads_mixing_factor',
+                        'cads_hr_fix_active',
+                ]
                 return [active, t1, t2, noise_scale, mixing_factor, rescale, apply_to_hr_pass]
 
         def before_process_batch(self, p, active, t1, t2, noise_scale, mixing_factor, rescale, apply_to_hr_pass, *args, **kwargs):


### PR DESCRIPTION
Adds paste fields for sending CADS parameters via "Send to X" buttons.